### PR TITLE
Small Quality of Life Changes

### DIFF
--- a/challenge_score.py
+++ b/challenge_score.py
@@ -75,6 +75,7 @@ class Qso():
         self._callsign = None
         self._name = None
         self._spc = None
+        self._mode = None
         self._licw_nr = None
         # Base points for QSO
         self._points = 0
@@ -89,7 +90,7 @@ class Qso():
     def is_valid(self):
         ''' Getter to determine if the QSO is valid '''
         # Need all the required fields
-        return self._band and self._callsign and self._name and self._spc and self._licw_nr and self._date
+        return self._band and self._callsign and self._name and self._spc and self._licw_nr and self._date and self._mode and self._mode.upper() == 'CW'
 
     @property
     def callsign(self):
@@ -110,6 +111,11 @@ class Qso():
     def spc(self):
         ''' Getter for SPC '''
         return self._spc
+
+    @property
+    def mode(self):
+        """ Getter for Mode """
+        return self._mode
 
     @property
     def name(self):
@@ -149,6 +155,7 @@ class Qso():
         self._licw_nr = None
         self._bonus_letters = None
         self._date = None
+        self._mode = None
         if 'BAND' in qso_fields:
             self._band = qso_fields['BAND']
         if 'CALL' in qso_fields:
@@ -160,6 +167,9 @@ class Qso():
                 self._date = int(qso_fields['QSO_DATE'])
             except ValueError:
                 pass
+        if 'MODE' in qso_fields:
+            self._mode = qso_fields['MODE']
+
         # The SPC and LICW number should be found in the comment field,
         # formatted with optional bonus letters and optional 3rd
         # field list as: LICW[SPC:1234is:FIRST,F2F]
@@ -206,7 +216,7 @@ class Qso():
                 if extra in BONUS:
                     self._bonus += BONUS[extra]
             # DX contact?
-            if len(self._spc) == 3:
+            if len(self._spc) == 3 or self._spc.upper() == 'DX':
                 self._bonus += BONUS['DX']
 
 # *******************************************************************

--- a/challenge_score.py
+++ b/challenge_score.py
@@ -35,6 +35,23 @@ BONUS = {
     'FIRST': 10
 }
 
+VALID_BANDS = [
+    '160M',
+    '80M',
+    '75M',
+    '60M',
+    '40M',
+    '30M',
+    '20M',
+    '17M',
+    '15M',
+    '12M',
+    '10M',
+    '6M',
+    '2M'
+]
+        
+
 # *******************************************************************
 #  Classes
 # *******************************************************************
@@ -87,10 +104,21 @@ class Qso():
             self.load_qso(qso_fields)
 
     @property
+    def band_is_valid(self):
+        """ The band  is valid """
+        return self._band and self._band.upper() in VALID_BANDS
+
+    @property
+    def mode_is_valid(self):
+        """ The mode is CW """
+        return self._mode and self._mode.upper() == 'CW'
+
+
+    @property
     def is_valid(self):
         ''' Getter to determine if the QSO is valid '''
         # Need all the required fields
-        return self._band and self._callsign and self._name and self._spc and self._licw_nr and self._date and self._mode and self._mode.upper() == 'CW'
+        return self.band_is_valid and self._callsign and self._name and self._spc and self._licw_nr and self._date and self.mode_is_valid
 
     @property
     def callsign(self):
@@ -535,7 +563,7 @@ def parse_logfile(filenames, quarter):
     # Parsing strategy: read file one line at a time, stripping
     # trailing newlines and then pass those to my stream parser.
     for filename in filenames:
-        with open(filename, 'r', encoding='utf-8') as logfile:
+        with open(filename, 'r') as logfile:
             while True:
                 line = logfile.readline()
                 if not line:


### PR DESCRIPTION
This Pull Request incorporates the following changes:

# Band Verification
The README mentions that it would be nice to verify that the QSO occurred on a valid band.  This was easy enough to add, so I did.

# Allow "DX" in comment to qualify for bonus points
The current implementation relies on the length of the string entered for the SPC. I ran into a case where a PR (Puerto Rico) station didn't give me the DX bonus.  Yes, I could have entered something like LtAmer or something to trigger the bonus but allowing "DX" seems like a reasonable option to me.

# Verify Mode
Some logging software automatically copies the comment from previous QSO's with the same station. This means that if the mode isn't verified, points for QSO's on non-CW modes could erroneously be granted points.

# Remove UTF-8 encoding when opening file
Windows doesn't use UTF-8 by default and I had issues opening ADI files exported in Windows when UTF-8 encoding was specified.  This change fixes the issue for Windows and still works in Linux.  I don't have a way to test on Mac.